### PR TITLE
fix: remove regex to test the access token format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@villedemontreal/jwt-validator",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@villedemontreal/jwt-validator",
-      "version": "5.9.1",
+      "version": "5.9.2",
       "license": "MIT",
       "dependencies": {
         "@types/nock": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villedemontreal/jwt-validator",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Module to validate JWT (JSON Web Tokens)",
   "main": "dist/src/index.js",
   "typings": "dist/src",

--- a/src/middleware/tokenTransformationMiddleware.ts
+++ b/src/middleware/tokenTransformationMiddleware.ts
@@ -33,8 +33,8 @@ export const tokenTransformationMiddleware: (
       }
 
       // Extract the access token value from the authorization header
-      const accessTokenRegExpArray = authHeader.split(' ');
-      const accessToken = accessTokenRegExpArray[1];
+      const accessTokenSegments = authHeader.split(' ');
+      const accessToken = accessTokenSegments[1];
 
       // Call the service endpoint to exchange the access token for a extended jwt
       superagent

--- a/src/middleware/tokenTransformationMiddleware.ts
+++ b/src/middleware/tokenTransformationMiddleware.ts
@@ -7,8 +7,6 @@ import { createInvalidAuthHeaderError, createInvalidJwtError } from '../models/c
 import { createLogger } from '../utils/logger';
 import superagent = require('superagent');
 
-const _regexAccessToken = /([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})/;
-
 const logger = createLogger('Token transformation middleware');
 
 /**
@@ -35,14 +33,7 @@ export const tokenTransformationMiddleware: (
       }
 
       // Extract the access token value from the authorization header
-      const accessTokenRegExpArray = _regexAccessToken.exec(authHeader);
-      if (accessTokenRegExpArray.length <= 1) {
-        throw createInvalidAuthHeaderError({
-          code: constants.errors.codes.INVALID_VALUE,
-          target: 'access_token',
-          message: 'could not find a valid access token from the authorization header',
-        });
-      }
+      const accessTokenRegExpArray = authHeader.split(' ');
       const accessToken = accessTokenRegExpArray[1];
 
       // Call the service endpoint to exchange the access token for a extended jwt


### PR DESCRIPTION
Due to the authentification migration, the format of the access token is not anymore uuid. So for the tokenTransformationMiddleware to work we need to remove the regex format check.
The access token can have other format like JWT or uuid now.