### PR TITLE
Feature/client ip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@villedemontreal/jwt-validator",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@villedemontreal/jwt-validator",
-      "version": "5.9.2",
+      "version": "5.9.3",
       "license": "MIT",
       "dependencies": {
         "@types/nock": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villedemontreal/jwt-validator",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "description": "Module to validate JWT (JSON Web Tokens)",
   "main": "dist/src/index.js",
   "typings": "dist/src",

--- a/src/config/configs.ts
+++ b/src/config/configs.ts
@@ -26,10 +26,14 @@ export class Configs {
    */
   private _cacheDuration: number = constants.default.cacheDuration;
 
-  private readonly _sourceProjectName = (): string => {
-    const sourcePackageJson = require(`${constants.appRoot}/package.json`);
-    return sourcePackageJson?.name ? sourcePackageJson.name : '';
-  };
+  /**
+   * When this library is used as a dependency in a project, the source project name will be the property name in the package.json of this project
+   *
+   * @private
+   * @type {string}
+   * @memberof Configs
+   */
+  private readonly _sourceProjectName: string;
 
   private _loggerCreator: (name: string) => ILogger;
   private _correlationIdProvider: () => string;
@@ -37,6 +41,8 @@ export class Configs {
   constructor() {
     this.libRoot = path.normalize(__dirname + '/../../..');
     this.isWindows = os.platform() === 'win32';
+    const sourcePackageJson = require(`${constants.appRoot}/package.json`);
+    this._sourceProjectName = sourcePackageJson?.name ? sourcePackageJson.name : '';
   }
 
   /**
@@ -134,8 +140,14 @@ export class Configs {
     this._correlationIdProvider = correlationIdProvider;
   }
 
-  public getSourceProjectName() {
-    return this._sourceProjectName();
+  /**
+   * Get the source project name where this library is imported
+   *
+   * @return {*}  {string}
+   * @memberof Configs
+   */
+  public getSourceProjectName(): string {
+    return this._sourceProjectName;
   }
 
   /**

--- a/src/config/configs.ts
+++ b/src/config/configs.ts
@@ -26,6 +26,11 @@ export class Configs {
    */
   private _cacheDuration: number = constants.default.cacheDuration;
 
+  private readonly _sourceProjectName = (): string => {
+    const sourcePackageJson = require(`${constants.appRoot}/package.json`);
+    return sourcePackageJson?.name ? sourcePackageJson.name : '';
+  };
+
   private _loggerCreator: (name: string) => ILogger;
   private _correlationIdProvider: () => string;
 
@@ -127,6 +132,10 @@ export class Configs {
    */
   public setCorrelationIdProvider(correlationIdProvider: () => string) {
     this._correlationIdProvider = correlationIdProvider;
+  }
+
+  public getSourceProjectName() {
+    return this._sourceProjectName();
   }
 
   /**

--- a/src/middleware/tokenTransformationMiddleware.ts
+++ b/src/middleware/tokenTransformationMiddleware.ts
@@ -4,6 +4,7 @@ import httpHeaderFieldsTyped from 'http-header-fields-typed';
 import * as _ from 'lodash';
 import { constants } from '../config/constants';
 import { ITokenTtransformationMiddlewareConfig } from '../config/tokenTransformationMiddlewareConfig';
+import { IInputAccessToken, IInputAccessTokenSource } from '../models/accessToken';
 import { createInvalidJwtError } from '../models/customError';
 import { createLogger } from '../utils/logger';
 import superagent = require('superagent');
@@ -67,10 +68,23 @@ export const tokenTransformationMiddleware: (
         return;
       }
 
+      const source: IInputAccessTokenSource = {
+        url: `${req.headers?.host}${req.url}`,
+        method: req.method,
+        serviceName: 'localAPI',
+        clientIp: '10.0.0.1',
+      };
+
+      const inputAccessToken: IInputAccessToken = {
+        accessToken,
+        source,
+        extensions: config.extensions,
+      };
+
       // Call the service endpoint to exchange the access token for a extended jwt
       superagent
         .post(config.service.uri)
-        .send({ accessToken, extensions: config.extensions })
+        .send(inputAccessToken)
         .then((response) => {
           const extendedJwt = response.body.jwts?.extended;
           logger.debug(extendedJwt, 'Extended jwt content.');

--- a/src/middleware/tokenTransformationMiddleware.ts
+++ b/src/middleware/tokenTransformationMiddleware.ts
@@ -2,6 +2,7 @@ import { utils } from '@villedemontreal/general-utils';
 import * as express from 'express';
 import httpHeaderFieldsTyped from 'http-header-fields-typed';
 import * as _ from 'lodash';
+import { configs } from '../config/configs';
 import { constants } from '../config/constants';
 import { ITokenTtransformationMiddlewareConfig } from '../config/tokenTransformationMiddlewareConfig';
 import { IInputAccessToken, IInputAccessTokenSource } from '../models/accessToken';
@@ -69,9 +70,9 @@ export const tokenTransformationMiddleware: (
       }
 
       const source: IInputAccessTokenSource = {
-        url: `${req.headers?.host}${req.url}`,
+        url: `${req.protocol}://${req?.headers.host}${req.url}`,
         method: req.method,
-        serviceName: 'localAPI',
+        serviceName: configs.getSourceProjectName(),
         clientIp: '10.0.0.1',
       };
 

--- a/src/models/accessToken.ts
+++ b/src/models/accessToken.ts
@@ -1,0 +1,35 @@
+/**
+ * An input access token
+ */
+export interface IInputAccessTokenExtensionsJwtCustomDataProvider {
+  uri: string;
+  method?: string;
+  options?: any;
+  name?: string;
+  useJwtInAuthHeader?: boolean;
+}
+export interface IInputAccessTokenExtensionsJwt {
+  customDataProvider: IInputAccessTokenExtensionsJwtCustomDataProvider;
+}
+
+export interface IInputAccessTokenExtensions {
+  jwt: IInputAccessTokenExtensionsJwt;
+}
+
+export interface IInputAccessTokenSource {
+  url: string;
+  method: string;
+  serviceName: string;
+  basicJwtCacheKey?: string; // the name of the cache key for the basic JWT, to use the same key as the Kong plugin
+  extendedJwtCacheKey?: string; // the name of the cache key for the extended JWT, to use the same key as the Kong plugin
+  extendedJwtConfigDigest?: string; // the digest that should be included in the extended JWT, to verify later that we retrieved a cached JWT matching the right config.
+  clientIp: string;
+}
+
+export interface IInputAccessToken {
+  accessToken: string;
+  accessTokenIssuer?: string;
+  source?: IInputAccessTokenSource;
+  jwt?: string;
+  extensions?: IInputAccessTokenExtensions;
+}


### PR DESCRIPTION
To call the Token API the source clientIp is mandatory. for the generic accounts this clientIp is not specified. The solution is to set this clientIp while requesting a JWT in tokenTransformationMiddleware.